### PR TITLE
top right BitPay logo redirects to homepage instead of blog homepage

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -6,7 +6,7 @@
 
     <nav class="main-nav overlay clearfix">
       <div class="main-header-content inner">
-        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
+        {{#if @blog.logo}}<a class="blog-logo" href="https://bitpay.com"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
         {{#if @blog.navigation}}
           <div class="menu-button">Menu</div>
         {{/if}}


### PR DESCRIPTION
Currently, blog.bitpay.com prevents users from easily navigating away from the blog and back to the website. The logo for the blog is the same for our website which creates confusion when someone comes from our site to the blog.